### PR TITLE
fix: Parameterize the type of the identity of the aggregate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ecubelabs/seed",
-  "version": "0.0.13-dist-test",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ecubelabs/seed",
-  "version": "0.0.13-dist-test",
+  "version": "0.1.0",
   "description": "Spring like framework for Node.js",
   "main": "index.js",
   "scripts": {

--- a/sample/index.ts
+++ b/sample/index.ts
@@ -35,7 +35,9 @@ class Person extends Aggregate<Person> {
   }
 }
 
-class PersonRepository extends TypeOrmRepository<Person> {
+class PersonRepository extends TypeOrmRepository<Person, number> {
+  entityClass = Person;
+
   async findAll(): Promise<Person[]> {
     return this.entityManager.find(Person);
   }
@@ -45,7 +47,7 @@ class PersonService extends Service {
   @Inject()
   private personRepository!: PersonRepository;
 
-  @Transactional()
+  // @Transactional()
   async create() {
     const person = new Person({ name: "charlie", age: 33 });
     await this.personRepository.save([person]);
@@ -53,6 +55,10 @@ class PersonService extends Service {
 
   async getAll(): Promise<Person[]> {
     return this.personRepository.findAll();
+  }
+
+  async get(id: number): Promise<Person> {
+    return this.personRepository.findOneOrFail(id);
   }
 }
 
@@ -91,5 +97,9 @@ async function sleep(ms: number) {
 
   console.log(await personService.getAll());
   await sleep(1000);
+
   await personService.create();
+  await sleep(1000);
+
+  console.log(await personService.get(1));
 })();

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -2,7 +2,7 @@ import { Inject } from "typedi";
 import { Aggregate } from "./aggregate";
 import { Context } from "./context";
 
-export abstract class Repository<T extends Aggregate<T>> {
+export abstract class Repository<T extends Aggregate<T>, ID> {
   @Inject()
   protected context!: Context;
 
@@ -10,4 +10,14 @@ export abstract class Repository<T extends Aggregate<T>> {
    * @param aggregates
    */
   abstract async save(aggregates: T[]): Promise<void>;
+
+  /**
+   * @param id
+   */
+  abstract async findOneOrFail(id: ID): Promise<T>;
+
+  /**
+   * @param ids
+   */
+  abstract async findByIds(ids: ID[]): Promise<T[]>;
 }

--- a/src/typeorm/type-orm-repository.ts
+++ b/src/typeorm/type-orm-repository.ts
@@ -1,8 +1,13 @@
-import { EntityManager, getManager } from "typeorm";
+import { EntityManager, getManager, ObjectType } from "typeorm";
 import { Aggregate } from "../aggregate";
 import { Repository } from "../repository";
 
-export abstract class TypeOrmRepository<T extends Aggregate<T>> extends Repository<T> {
+export abstract class TypeOrmRepository<
+  T extends Aggregate<T>,
+  ID
+> extends Repository<T, ID> {
+  protected abstract entityClass: ObjectType<T>;
+
   /**
    *
    */
@@ -18,5 +23,19 @@ export abstract class TypeOrmRepository<T extends Aggregate<T>> extends Reposito
    */
   async save(aggregates: T[]) {
     await this.entityManager.save(aggregates);
+  }
+
+  /**
+   * @param id
+   */
+  async findOneOrFail(id: ID): Promise<T> {
+    return this.entityManager.findOneOrFail(this.entityClass, id);
+  }
+
+  /**
+   * @param ids
+   */
+  async findByIds(ids: ID[]): Promise<T[]> {
+    return this.entityManager.findByIds(this.entityClass, ids);
   }
 }


### PR DESCRIPTION
[참고 했던 소스](https://docs.spring.io/spring-data/jpa/docs/current/api/org/springframework/data/jpa/repository/JpaRepository.html)에서 ID 가 parameterize 되어 있기도 하고 기존의 프로젝트에서도 이를 따르고 있어서 seed 에 반영했습니다.