### PR TITLE
refactor: DDD Types Improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ecubelabs/seed",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ecubelabs/seed",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ecubelabs/seed",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ecubelabs/seed",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Spring like framework for Node.js",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ecubelabs/seed",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Spring like framework for Node.js",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ecubelabs/seed",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Spring like framework for Node.js",
   "main": "index.js",
   "scripts": {

--- a/src/context.ts
+++ b/src/context.ts
@@ -57,7 +57,7 @@ export class Context {
   /**
    * @param txId
    */
-  private constructor(txId: string) {
+  protected constructor(txId: string) {
     const containerId = uuid();
     const container = Container.of(containerId);
     container.set(Context, this);

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,5 +1,5 @@
 import * as uuid from "uuid/v4";
-import { Container } from "typedi";
+import { Container, Token } from "typedi";
 
 type ClassType<T> = new (...args: any[]) => T;
 
@@ -29,30 +29,30 @@ export class Context {
   /**
    * @param type
    */
-  get<T>(type: ClassType<T>): T {
+  get<T>(type: ClassType<T> | Token<T>): T {
     return this._get(type);
   }
 
-  private _get: <T>(type: ClassType<T>) => T;
+  private _get: <T>(type: ClassType<T> | Token<T>) => T;
 
   /**
    * @param type
    * @param instance
    */
-  set<T>(type: ClassType<T>, instance: T) {
+  set<T>(type: ClassType<T> | Token<T>, instance: T) {
     this._set(type, instance);
   }
 
-  private _set: <T>(type: ClassType<T>, instance: T) => void;
+  private _set: <T>(type: ClassType<T> | Token<T>, instance: T) => void;
 
   /**
    * @param type
    */
-  has<T>(type: ClassType<T>): boolean {
+  has<T>(type: ClassType<T> | Token<T>): boolean {
     return this._has(type);
   }
 
-  private _has: <T>(type: ClassType<T>) => boolean;
+  private _has: <T>(type: ClassType<T> | Token<T>) => boolean;
 
   /**
    * @param txId
@@ -68,10 +68,10 @@ export class Context {
       Container.reset(containerId);
     };
 
-    this._get = type => container.get(type);
+    this._get = (type) => container.get(type as any); // HACK: overload 문제 해결 후 any 제거
 
     this._set = (type, instance) => container.set(type, instance);
 
-    this._has = type => container.has(type);
+    this._has = (type) => container.has(type as any); // HACK: overload 문제 해결 후 any 제거
   }
 }

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -2,9 +2,9 @@ import { Inject } from "typedi";
 import { Aggregate } from "./aggregate";
 import { Context } from "./context";
 
-export abstract class Repository<T extends Aggregate<T>, ID, C extends Context = Context> {
+export abstract class Repository<T extends Aggregate<T>, ID> {
   @Inject()
-  protected context!: C;
+  protected context!: Context;
 
   /**
    * @param aggregates

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -2,22 +2,22 @@ import { Inject } from "typedi";
 import { Aggregate } from "./aggregate";
 import { Context } from "./context";
 
-export abstract class Repository<T extends Aggregate<T>, ID> {
+export abstract class Repository<T extends Aggregate<T>, ID, C extends Context = Context> {
   @Inject()
-  protected context!: Context;
+  protected context!: C;
 
   /**
    * @param aggregates
    */
-  abstract async save(aggregates: T[]): Promise<void>;
+  abstract save(aggregates: T[]): Promise<void>;
 
   /**
    * @param id
    */
-  abstract async findOneOrFail(id: ID): Promise<T>;
+  abstract findOneOrFail(id: ID): Promise<T>;
 
   /**
    * @param ids
    */
-  abstract async findByIds(ids: ID[]): Promise<T[]>;
+  abstract findByIds(ids: ID[]): Promise<T[]>;
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -1,7 +1,11 @@
 import { Inject } from "typedi";
+import { Context } from "./context";
 import { TransactionManager } from "./transaction-manager";
 
 export abstract class Service {
+  @Inject()
+  context!: Context;
+
   @Inject()
   transactionManager!: TransactionManager;
 }

--- a/src/typeorm/type-orm-repository.ts
+++ b/src/typeorm/type-orm-repository.ts
@@ -5,9 +5,8 @@ import { Repository } from "../repository";
 
 export abstract class TypeOrmRepository<
   T extends Aggregate<T>,
-  ID,
-  C extends Context
-> extends Repository<T, ID, C> {
+  ID
+> extends Repository<T, ID> {
   protected abstract entityClass: ObjectType<T>;
 
   /**

--- a/src/typeorm/type-orm-repository.ts
+++ b/src/typeorm/type-orm-repository.ts
@@ -1,11 +1,13 @@
 import { EntityManager, getManager, ObjectType } from "typeorm";
 import { Aggregate } from "../aggregate";
+import { Context } from "../context";
 import { Repository } from "../repository";
 
 export abstract class TypeOrmRepository<
   T extends Aggregate<T>,
-  ID
-> extends Repository<T, ID> {
+  ID,
+  C extends Context
+> extends Repository<T, ID, C> {
   protected abstract entityClass: ObjectType<T>;
 
   /**

--- a/src/typeorm/type-orm-repository.ts
+++ b/src/typeorm/type-orm-repository.ts
@@ -1,6 +1,5 @@
 import { EntityManager, getManager, ObjectType } from "typeorm";
 import { Aggregate } from "../aggregate";
-import { Context } from "../context";
 import { Repository } from "../repository";
 
 export abstract class TypeOrmRepository<


### PR DESCRIPTION
- 상속 불가능한 Context 생성자 변경 (private -> protected)
- ~~Repository로 인젝션 받는 Context 타입 제네릭으로 관리~~
- Context에서 typedi의 Token도 입력받을 수 있도록 수정
(overload된 메서드에 문제가 있는데 해결하려다 보니 코드가 너무 지저분해져서 any 처리)
![image](https://user-images.githubusercontent.com/10769487/119444629-80ca7d80-bd66-11eb-8c40-045a0dd4325e.png)
