### PR TITLE
chore: bump patch version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ecubelabs/seed",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ecubelabs/seed",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Spring like framework for Node.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
0.2.0은 publish를 잘못했음.
0.2.1과 0.2.0의 형상은 같고 republish.